### PR TITLE
Add audio normalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,3 @@ A Python script to download & re-encode videos to be faster
 Requires Python 3, and `ffmpeg` and `ffprobe` in your PATH.
 
 `pipenv run python3 speeder_upper.py --codec x265 --dearrow "https://www.youtube.com/watch?v=0EqSXDwTq6U"`
-
-
-# Roadmap
-
-- Loudness normalization for quiet videos using [ffmpeg-normalize](https://github.com/slhck/ffmpeg-normalize#api)

--- a/speeder_upper.py
+++ b/speeder_upper.py
@@ -55,6 +55,7 @@ def codec_hevc_nvenc(v1, a1, tmp_file, framerate):
         r=framerate,
         **{
             "metadata:s:a:0": "language=eng",
+            "filter:a": "dynaudnorm",
         },
     )
 
@@ -80,6 +81,7 @@ def codec_hevc_qsv(v1, a1, tmp_file, framerate):
         r=framerate,
         **{
             "metadata:s:a:0": "language=eng",
+            "filter:a": "dynaudnorm",
         },
     )
 
@@ -105,6 +107,7 @@ def codec_av1_nvenc(v1, a1, tmp_file, framerate):
         r=framerate,
         **{
             "metadata:s:a:0": "language=eng",
+            "filter:a": "dynaudnorm",
         },
     )
 
@@ -128,6 +131,7 @@ def codec_x264(v1, a1, tmp_file, framerate):
         r=framerate,
         **{
             "metadata:s:a:0": "language=eng",
+            "filter:a": "dynaudnorm",
         },
     )
 
@@ -152,6 +156,7 @@ def codec_x265(v1, a1, tmp_file, framerate):
         r=framerate,
         **{
             "metadata:s:a:0": "language=eng",
+            "filter:a": "dynaudnorm",
         },
     )
 
@@ -174,6 +179,7 @@ def codec_av1(v1, a1, tmp_file, framerate):
         **{
             "metadata:s:a:0": "language=eng",
             "svtav1-params": "fast-decode=1:enable-overlays=1:lookahead=0:scd=1:enable-qm=1",
+            "filter:a": "dynaudnorm",
         },
     )
 


### PR DESCRIPTION
Uses FFmpeg built-in filters through commmand line argument `-filter:a "dynaudnorm"` in order to normalize output as mentioned in roadmap. If you would prefer to use ffmpeg-normalize as mentioned, feel free to reject this pull. 